### PR TITLE
Tick to commons-codec 1.5.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -15,7 +15,7 @@ HTTPCLIENT = 'org.apache.httpcomponents:httpclient:jar:4.1.1'
 HTTPCORE = 'org.apache.httpcomponents:httpcore:jar:4.1'
 COMMONSLOG = 'commons-logging:commons-logging:jar:1.1.1'
 
-CODEC = 'commons-codec:commons-codec:jar:1.3'
+CODEC = 'commons-codec:commons-codec:jar:1.5'
 
 SLF4J_VERSION = "1.5.6"
 SLF4J = [


### PR DESCRIPTION
commons-codec 1.3 is technically fine, but 1.4 changes the behavior
of Base64 encoding in a way that breaks the AWS signature:

https://issues.apache.org/jira/browse/CODEC-97

Requiring 1.5 seems like a good way to prevent 1.4 from accidentally slipping
into the classpath.
